### PR TITLE
Using defcustom instead defvar for projections commands variables

### DIFF
--- a/src/projection-commands.el
+++ b/src/projection-commands.el
@@ -135,7 +135,7 @@ Is a list of cmd-type records of the form
 It takes precedence over the default command for the project type when set.
 Should be set via .dir-locals.el."
                   cmd-symbol)
-         :type '(string)
+         :type '(optional string)
          :safe #'stringp)
 
        (defcustom ,pre-hook-symbol nil

--- a/src/projection-commands.el
+++ b/src/projection-commands.el
@@ -130,7 +130,7 @@ Is a list of cmd-type records of the form
     `(progn
        (projection--log :debug "Defining project command of type=%s" ',cmd-type)
 
-       (defcustom ,cmd-var-symbol ""
+       (defcustom ,cmd-var-symbol nil
          ,(format "The command to use with `%s'.
 It takes precedence over the default command for the project type when set.
 Should be set via .dir-locals.el."

--- a/src/projection-commands.el
+++ b/src/projection-commands.el
@@ -130,22 +130,27 @@ Is a list of cmd-type records of the form
     `(progn
        (projection--log :debug "Defining project command of type=%s" ',cmd-type)
 
-       (defvar ,cmd-var-symbol nil
+       (defcustom ,cmd-var-symbol ""
          ,(format "The command to use with `%s'.
 It takes precedence over the default command for the project type when set.
 Should be set via .dir-locals.el."
-                  cmd-symbol))
+                  cmd-symbol)
+         :type '(string)
+         :safe t)
 
-       (defvar ,pre-hook-symbol nil
+       (defcustom ,pre-hook-symbol nil
          ,(format "Hook variable run immediately before `%s'.
 Currently this hook will be invoked with a plist containing the project.
 It may be updated to take more arguments at a later date."
-                  (symbol-name cmd-symbol)))
-       (defvar ,post-hook-symbol nil
+                  (symbol-name cmd-symbol))
+         :type 'hook)
+
+       (defcustom ,post-hook-symbol nil
          ,(format "Hook variable run immediately after `%s'.
 Accepts the same arguments as `%s'."
                   (symbol-name cmd-symbol)
-                  (symbol-name pre-hook-symbol)))
+                  (symbol-name pre-hook-symbol))
+         :type 'hook)
 
        (projection--declare-cache-var
          ',cmd-type

--- a/src/projection-commands.el
+++ b/src/projection-commands.el
@@ -136,7 +136,7 @@ It takes precedence over the default command for the project type when set.
 Should be set via .dir-locals.el."
                   cmd-symbol)
          :type '(string)
-         :safe t)
+         :safe #'stringp)
 
        (defcustom ,pre-hook-symbol nil
          ,(format "Hook variable run immediately before `%s'.


### PR DESCRIPTION
Using Projection command variables in .dir-locals cause showing those variables as unsafe, this can be fixed using a defcustom.

Also using defcustom makes them more easy to modify with recently customize-dirlocals in emacs 30.
