### PR TITLE
projection-multi: Silence missing defvar warnings

### DIFF
--- a/src/projection-multi/projection-multi-cmake.el
+++ b/src/projection-multi/projection-multi-cmake.el
@@ -142,6 +142,8 @@ When set the generated targets will be prefixed with PROJECT-TYPE."
    `((t ,#'projection-multi-cmake-targets))))
 
 ;;;###autoload
+(defvar projection-project-type-cmake)
+;;;###autoload
 (with-eval-after-load 'projection-types
   (projection-type-append-compile-multi-targets projection-project-type-cmake
     #'projection-multi-cmake-targets))

--- a/src/projection-multi/projection-multi-ctest.el
+++ b/src/projection-multi/projection-multi-ctest.el
@@ -96,6 +96,8 @@ When set the generated targets will be prefixed with PROJECT-TYPE."
    `((t ,#'projection-multi-ctest-targets))))
 
 ;;;###autoload
+(defvar projection-project-type-cmake)
+;;;###autoload
 (with-eval-after-load 'projection-types
   (projection-type-append-compile-multi-targets projection-project-type-cmake
     #'projection-multi-ctest-targets))

--- a/src/projection-multi/projection-multi-golang.el
+++ b/src/projection-multi/projection-multi-golang.el
@@ -46,6 +46,8 @@ When set the generated targets will be prefixed with PROJECT-TYPE."
    `((t ,#'projection-multi-golang-targets))))
 
 ;;;###autoload
+(defvar projection-project-type-golang)
+;;;###autoload
 (with-eval-after-load 'projection-types
   (projection-type-append-compile-multi-targets projection-project-type-golang
     #'projection-multi-golang-targets))

--- a/src/projection-multi/projection-multi-gradle.el
+++ b/src/projection-multi/projection-multi-gradle.el
@@ -102,6 +102,8 @@ When set the generated targets will be prefixed with PROJECT-TYPE."
    `((t ,#'projection-multi-gradle-targets))))
 
 ;;;###autoload
+(defvar projection-project-type-gradle)
+;;;###autoload
 (with-eval-after-load 'projection-types
   (projection-type-append-compile-multi-targets projection-project-type-gradle
     #'projection-multi-gradle-targets))

--- a/src/projection-multi/projection-multi-make.el
+++ b/src/projection-multi/projection-multi-make.el
@@ -109,6 +109,8 @@ the first Makefile it finds in the current directory."
    `((t ,#'projection-multi-make-targets))))
 
 ;;;###autoload
+(defvar projection-project-type-make)
+;;;###autoload
 (with-eval-after-load 'projection-types
   (projection-type-append-compile-multi-targets projection-project-type-make
     #'projection-multi-make-targets))

--- a/src/projection-multi/projection-multi-meson.el
+++ b/src/projection-multi/projection-multi-meson.el
@@ -73,6 +73,8 @@ When set the generated targets will be prefixed with PROJECT-TYPE."
    `((t ,#'projection-multi-meson-targets))))
 
 ;;;###autoload
+(defvar projection-project-type-meson)
+;;;###autoload
 (with-eval-after-load 'projection-types
   (projection-type-append-compile-multi-targets projection-project-type-meson
     #'projection-multi-meson-targets))

--- a/src/projection-multi/projection-multi-npm-scripts.el
+++ b/src/projection-multi/projection-multi-npm-scripts.el
@@ -94,6 +94,8 @@ When set the generated targets will be prefixed with PROJECT-TYPE."
    `((t ,#'projection-multi-npm-script-targets))))
 
 ;;;###autoload
+(defvar projection-project-type-npm)
+;;;###autoload
 (with-eval-after-load 'projection-types
   (projection-type-append-compile-multi-targets projection-project-type-npm
     #'projection-multi-npm-script-targets))

--- a/src/projection-multi/projection-multi-poetry-poe.el
+++ b/src/projection-multi/projection-multi-poetry-poe.el
@@ -109,6 +109,8 @@ When set the generated targets will be prefixed with PROJECT-TYPE."
    `((t ,#'projection-multi-poetry-poe-targets))))
 
 ;;;###autoload
+(defvar projection-project-type-python-poetry)
+;;;###autoload
 (with-eval-after-load 'projection-types
   (projection-type-append-compile-multi-targets projection-project-type-python-poetry
     #'projection-multi-poetry-poe-targets))

--- a/src/projection-multi/projection-multi-pytest.el
+++ b/src/projection-multi/projection-multi-pytest.el
@@ -135,6 +135,20 @@
    `((t ,#'projection-multi-pytest-targets))))
 
 ;;;###autoload
+(defvar projection-project-type-django)
+;;;###autoload
+(defvar projection-project-type-python-pip)
+;;;###autoload
+(defvar projection-project-type-python-pkg)
+;;;###autoload
+(defvar projection-project-type-python-toml)
+;;;###autoload
+(defvar projection-project-type-python-tox)
+;;;###autoload
+(defvar projection-project-type-python-pipenv)
+;;;###autoload
+(defvar projection-project-type-python-poetry)
+;;;###autoload
 (with-eval-after-load 'projection-types
   (projection-type-append-compile-multi-targets
     (list projection-project-type-django

--- a/src/projection-multi/projection-multi-rustic.el
+++ b/src/projection-multi/projection-multi-rustic.el
@@ -74,6 +74,8 @@ When set the generated targets will be prefixed with PROJECT-TYPE."
    `((t ,#'projection-multi-rustic-targets))))
 
 ;;;###autoload
+(defvar projection-project-type-rust-cargo)
+;;;###autoload
 (with-eval-after-load 'projection-types
   (projection-type-append-compile-multi-targets projection-project-type-rust-cargo
     #'projection-multi-rustic-targets))

--- a/src/projection-multi/projection-multi-tox.el
+++ b/src/projection-multi/projection-multi-tox.el
@@ -95,6 +95,8 @@ When set the generated targets will be prefixed with PROJECT-TYPE."
    `((t ,#'projection-multi-tox-targets))))
 
 ;;;###autoload
+(defvar projection-project-type-python-tox)
+;;;###autoload
 (with-eval-after-load 'projection-types
   (projection-type-append-compile-multi-targets projection-project-type-python-tox
     #'projection-multi-tox-targets))

--- a/src/projection-multi/projection-multi-vscode-tasks.el
+++ b/src/projection-multi/projection-multi-vscode-tasks.el
@@ -108,6 +108,8 @@ When set the generated targets will be prefixed with PROJECT-TYPE."
    `((t ,#'projection-multi-compile-vscode-targets))))
 
 ;;;###autoload
+(defvar projection-project-type-vscode-tasks)
+;;;###autoload
 (with-eval-after-load 'projection-types
   (projection-type-append-compile-multi-targets projection-project-type-vscode-tasks
     #'projection-multi-compile-vscode-targets))

--- a/src/projection-multi/projection-multi-yarn-scripts.el
+++ b/src/projection-multi/projection-multi-yarn-scripts.el
@@ -108,6 +108,8 @@ When set the generated targets will be prefixed with PROJECT-TYPE."
    `((t ,#'projection-multi-yarn-script-targets))))
 
 ;;;###autoload
+(defvar projection-project-type-yarn)
+;;;###autoload
 (with-eval-after-load 'projection-types
   (projection-type-append-compile-multi-targets projection-project-type-yarn
     #'projection-multi-yarn-script-targets))


### PR DESCRIPTION
These `defvar`s doesn't have `autoload`s (and probably shouldn't at this point)
so add empty definitions to silence the compiler.