### PR TITLE
Support Babashka tasks in multi-compile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ RUN apt-get update \
  && apt-get update \
  && apt-get install -y cmake npm yarnpkg ninja-build golang meson gradle python3-pytest \
  && apt-get clean \
+ && curl -s https://raw.githubusercontent.com/babashka/babashka/master/install | bash \
  && npm install -g yarn \
  && rm -rf /var/lib/apt/lists/*
 

--- a/README.org
+++ b/README.org
@@ -198,7 +198,7 @@ very targeted support for some project types like [[https://cmake.org/][CMake]].
    - Make
    - Poetry Poe
    - Tox
-
+   - Babashka
 
 ** Projection multi-embark
 #+html: <p align="right">

--- a/src/projection-multi/projection-multi-bb.el
+++ b/src/projection-multi/projection-multi-bb.el
@@ -53,9 +53,9 @@
 (defvar projection-multi-bb--parser-expression
   "
 (for [i *input*
-      [task-name {task-doc :doc}] (:tasks i)
+      [task-name task-body] (:tasks i)
       :when (symbol? task-name)]
-  (str task-name (char 0) task-doc))
+  (str task-name (char 0) (:doc task-body)))
 "
   "A Babashka expression that will read bb.edn structures from *input*, and
 evaluate to a sequence of strings.  Each string is the task name, a null byte,

--- a/src/projection-multi/projection-multi-bb.el
+++ b/src/projection-multi/projection-multi-bb.el
@@ -1,0 +1,116 @@
+;;; projection-multi-bb.el --- Projection integration for `compile-multi' and Babashka tasks. -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2025  Mohsin Kaleem
+
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; This library exposes a target generation function for `compile-multi' which
+;; sources the list of available tasks from a Babshka project's bb.edn.
+
+;;; Code:
+
+(require 'cl-lib)
+(require 'projection-core)
+(require 'projection-multi)
+(require 'projection-types)
+
+(defgroup projection-multi-bb nil
+  "Helpers for `compile-multi' and Babashka projects."
+  :group 'projection-multi)
+
+(defcustom projection-multi-bb-executable "bb"
+  "Path to a Babashka executable used to query available tasks."
+  :type 'string
+  :group 'projection-multi-bb)
+
+(defcustom projection-multi-bb-cache-tasks 'auto
+  "When true cache the Babashka tasks of each project."
+  :type '(choice
+          (const :tag "Cache targets and invalidate cache automatically" auto)
+          (boolean :tag "Always/Never cache targets"))
+  :group 'projection-multi-bb)
+
+(projection--declare-cache-var
+  'projection-multi-bb-tasks
+  :title "Multi Babashka tasks"
+  :category "Babashka"
+  :description "Babashka tasks associated with this project"
+  :hide t)
+
+(defvar projection-multi-bb--parser-expression
+  "
+(for [i *input*
+      [task-name {task-doc :doc}] (:tasks i)
+      :when (symbol? task-name)]
+  (str task-name (char 0) task-doc))
+"
+  "A Babashka expression that will read bb.edn structures from *input*, and
+evaluate to a sequence of strings.  Each string is the task name, a null byte,
+then the task description.")
+
+;;;###autoload
+(defun projection-multi-bb--tasks2 ()
+  "`compile-multi' target generator function for Babashka tasks.  Returns a list
+of lists each of form (TASK-NAME TASK-DESCRIPTION)."
+  ;; REVIEW: This procedure parses the output of 
+  (projection--log :debug "Resolving available Babashka tasks")
+  (projection--with-shell-command-buffer
+    ;; Important not to quote the redirection!
+    (format "%s < bb.edn %s"
+            (shell-quote-argument projection-multi-bb-executable)
+            (projection--join-shell-command
+             `("-I" "-o" "-e" ,projection-multi-bb--parser-expression)))
+    (save-match-data
+      (mapcar (lambda (line)
+                (split-string line "\0"))
+              (split-string (buffer-string) "\n" t (rx whitespace))))))
+
+;;;###autoload
+(defun projection-multi-bb--tasks ()
+  (projection--cache-get-with-predicate
+   (projection--current-project 'no-error)
+   'projection-multi-bb-tasks
+   (cond ((eq projection-multi-bb-cache-tasks 'auto)
+          (projection--cache-modtime-predicate "bb.edn"))
+         (t projection-multi-bb-cache-tasks))
+   #'projection-multi-bb--tasks2))
+
+;;;###autoload
+(defun projection-multi-bb-targets ()
+  "Generator for `compile-multi' targets for Babashka tasks."
+  (cl-loop for (task-name doc) in (projection-multi-bb--tasks)
+           collect (list (concat "bb:" task-name)
+                         :command (projection--join-shell-command
+                                   (list projection-multi-bb-executable
+                                         "run" task-name))
+                         :annotation doc)))
+
+;;;###autoload
+(defun projection-multi-bb ()
+  "`compile-multi' wrapper for only Babashka tasks."
+  (interactive)
+  (projection-multi-compile--run
+   (projection--current-project 'no-error)
+   `((t ,#'projection-multi-bb-targets))))
+
+;;;###autoload
+(with-eval-after-load 'projection-types
+  (projection-type-append-compile-multi-targets
+    (list projection-project-type-babashka)
+    #'projection-multi-bb-targets))
+
+(provide 'projection-multi-bb)
+;;; projection-multi-bb.el ends here

--- a/src/projection-multi/projection-multi-bb.el
+++ b/src/projection-multi/projection-multi-bb.el
@@ -57,15 +57,14 @@
       :when (symbol? task-name)]
   (str task-name (char 0) (:doc task-body)))
 "
-  "A Babashka expression that will read bb.edn structures from *input*, and
-evaluate to a sequence of strings.  Each string is the task name, a null byte,
-then the task description.")
+  "Parse tasks from bb.edn. A Babashka expression that will read bb.edn
+structures from *input*, and evaluate to a sequence of strings.  Each string is
+the task name, a null byte, then the task description.")
 
 ;;;###autoload
 (defun projection-multi-bb--tasks2 ()
-  "`compile-multi' target generator function for Babashka tasks.  Returns a list
-of lists each of form (TASK-NAME TASK-DESCRIPTION)."
-  ;; REVIEW: This procedure parses the output of 
+  "A `compile-multi' target generator function for Babashka tasks.  Returns a
+list of lists each of form (TASK-NAME TASK-DESCRIPTION)."
   (projection--log :debug "Resolving available Babashka tasks")
   (projection--with-shell-command-buffer
     ;; Important not to quote the redirection!
@@ -80,6 +79,7 @@ of lists each of form (TASK-NAME TASK-DESCRIPTION)."
 
 ;;;###autoload
 (defun projection-multi-bb--tasks ()
+  "Read tasks from bb.edn respecting project-cache."
   (projection--cache-get-with-predicate
    (projection--current-project 'no-error)
    'projection-multi-bb-tasks

--- a/src/projection-types.el
+++ b/src/projection-types.el
@@ -600,6 +600,16 @@ Set TARGET as the TARGET to build when set."
 
 
 
+(defvar projection-project-type-babashka
+  (projection-type
+   :name 'babashka
+   :predicate "bb.edn"
+   :test-suffix "_test"))
+
+(add-to-list 'projection-project-types projection-project-type-babashka 'append)
+
+
+
 (defvar projection-project-type-bloop
   (projection-type
    :name 'bloop

--- a/test/integration/test-projection-type-babashka.el
+++ b/test/integration/test-projection-type-babashka.el
@@ -1,0 +1,56 @@
+;; -*- lexical-binding: t -*-
+
+(require 'projection-types)
+
+(require 'projection-multi-bb)
+(require 'projection-test-utils)
+
+(describe "Project type Babashka"
+          (+projection-test-setup)
+
+          (before-each
+           (setq projection-project-types (list projection-project-type-babashka))
+           (+projection-setup-project
+            '(("bb.edn" . "
+{:tasks
+ {:requires ([babashka.fs :as fs]
+             [clojure.edn :as edn]
+             [clojure.pprint :as pp]
+             [clojure.string :as str])
+
+  clean {:doc \"Delete build artifacts.\"
+         :task (do (fs/delete-tree \".shadow-cljs\")
+                   (fs/delete-tree \"lib\"))}
+
+  compile {:doc \"Build the project.\"
+           :task
+           (build
+             (wrap-cmd \"-M -m shadow.cljs.devtools.cli --force-spawn compile modules\")
+             *command-line-args*)}
+
+  dev {:doc \"Run shadow in watch mode with tests enabled.\"
+       :task
+       (binding [*test* true]
+         (println \"Starting shadow-cljs in watch mode.\")
+         (clojure \"-M -m shadow.cljs.devtools.cli --force-spawn watch modules\"))}
+
+  task-without-doc (shell \"no doc!!\")
+
+  release {:depends [clean]
+           :doc \"Compiles release build.\"
+           :task (shell \"build build build\")}}}"))))
+
+          (it "Can be identified"
+              (+projection-project-matches-p 'babashka))
+
+          (describe "Multi compile"
+                    (before-all (require 'projection-multi-bb))
+
+                    (it "Can extract tasks from bb.edn"
+                        (let ((targets (projection-multi-bb--tasks)))
+                          (expect targets :to-equal
+                                  '(("clean" "Delete build artifacts.")
+                                    ("compile" "Build the project.")
+                                    ("dev" "Run shadow in watch mode with tests enabled.")
+                                    ("task-without-doc" "")
+                                    ("release" "Compiles release build.")))))))


### PR DESCRIPTION
Adds the [Babashka](https://babashka.org/) project type, and projection-multi-compile support for running Babashka [tasks](https://book.babashka.org/#tasks), which are often used in Clojure projects.